### PR TITLE
Update autolabeler config to match any file with gradle in it

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -37,7 +37,7 @@ INFRA:
   - "jitpack.yml"
   - "travis.yml"
 BUILD:
-  - "**gradle**"
+  - "*gradle*"
   - "versions.props"
 DOCS:
   - "/site"


### PR DESCRIPTION
Merging this locally to test any file with gradle in it gets picked up properly