### PR TITLE
Add quotes on single substring match

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -37,9 +37,9 @@ BUILD:
     - versions.props
 DOCS:
   - any:
-    - /site
-    - **CHANGELOG.md
-    - **README.md
+    - /site/**/*
+    - "**CHANGELOG.md"
+    - "**README.md"
 LICENSE:
   - any:
     - "**LICENSE"


### PR DESCRIPTION
Current labeler config has errors in it when GH action runs.