### PR TITLE
Test Cancel Duplicate Workflow Runs Github Action in Fork

### DIFF
--- a/.github/workflows/cancel-dupliate-workflow-runs.yml
+++ b/.github/workflows/cancel-dupliate-workflow-runs.yml
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Canel Duplicates""
+on:
+  workflow_run:
+    workflows: 
+      - 'Java CI'
+    types: ['requested', 'completed']
+
+jobs:
+  cancel-duplicate-workflow-runs:
+    name: "Cancel Duplicate Workflow Runs"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: potiuk/cancel-workflow-runs@4723494a065d162f8e9efd071b98e0126e00f866 # @master
+        name: "Cancel duplicate workflow runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          skipEventTypes: '["push", "schedule"]'  # TODO - May not to remove push from skipEventTypes


### PR DESCRIPTION
Might need to be enabled etc.

This is to test (in a fork, which is somewhat different but should ideally be supported) before going upstream.