### PR TITLE
Test cross-workflow file failure in a concurrency group

### DIFF
--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
@@ -82,6 +82,10 @@ public final class TaskCheckHelper {
         expected.splitOffsets(), actual.splitOffsets());
     Assert.assertEquals("Should match the serialized record offsets",
         expected.keyMetadata(), actual.keyMetadata());
+
+    Assert.fail(
+        "Failing this test purposefully to check if failures in the spark CI DAG will fail jobs in the Flink CI DAG"
+    );
   }
 
   private static List<FileScanTask> getFileScanTasksInFilePathOrder(BaseCombinedScanTask task) {


### PR DESCRIPTION
- Also check if the draft check has effect or not.


Github Action DAGs are very non-sensical. For example, leaf nodes in the DAG need to know about and control behavior of their parents and grandparents - even if skipped.

So I doubt this will work but it's worth a shot.